### PR TITLE
src/sercon.c: enable terminal reset to prevent cursor sync failures

### DIFF
--- a/src/sercon.c
+++ b/src/sercon.c
@@ -99,6 +99,7 @@ static void sercon_putchar(u8 chr)
     }
 }
 
+/* Reset terminal to initial state */
 static void sercon_term_reset(void)
 {
     sercon_putchar('\x1b');
@@ -349,8 +350,9 @@ static void sercon_1000(struct bregs *regs)
     sercon_term_reset();
     sercon_term_no_linewrap();
 
-    if (clearscreen)
+    if (clearscreen) {
          sercon_term_clear_screen();
+    }
 }
 
 /* Set text-mode cursor shape */


### PR DESCRIPTION
Revert some changes in 1.11.0.1 which caused cursor sync failure in 1/10 cases.