### PR TITLE
hw/usb: increase wait time after host controller reset and post power

### DIFF
--- a/src/hw/usb-xhci.c
+++ b/src/hw/usb-xhci.c
@@ -312,7 +312,7 @@ static int wait_bit(u32 *reg, u32 mask, int value, u32 timeout)
  * Root hub
  ****************************************************************/
 
-#define XHCI_TIME_POSTPOWER 250
+#define XHCI_TIME_POSTPOWER 500
 
 // Check if device attached to port
 static void
@@ -472,9 +472,9 @@ configure_xhci(void *data)
 
     dprintf(3, "%s: resetting\n", __func__);
     writel(&xhci->op->usbcmd, XHCI_CMD_HCRST);
-    if (wait_bit(&xhci->op->usbcmd, XHCI_CMD_HCRST, 0, 500) != 0)
+    if (wait_bit(&xhci->op->usbcmd, XHCI_CMD_HCRST, 0, 1000) != 0)
         goto fail;
-    if (wait_bit(&xhci->op->usbsts, XHCI_STS_CNR, 0, 500) != 0)
+    if (wait_bit(&xhci->op->usbsts, XHCI_STS_CNR, 0, 1000) != 0)
         goto fail;
 
     writel(&xhci->op->config, xhci->slots);

--- a/src/hw/usb.h
+++ b/src/hw/usb.h
@@ -78,7 +78,7 @@ struct usbhub_op_s {
  ****************************************************************/
 
 // USB mandated timings (in ms)
-#define USB_TIME_SIGATT 1000 // 100		// WIV changed to 1000 to give USB3.x sticks with stall response a chance to be detected
+#define USB_TIME_SIGATT 2500 // 100		// WIV changed to 2500 to give USB devices enough time to be detected and enumerated
 #define USB_TIME_ATTDB  100
 #define USB_TIME_DRST   10
 #define USB_TIME_DRSTR  50


### PR DESCRIPTION
Based on the tests with new USB sticks. SanDisk stick causes timeout of the
host controller reset. Increase the timeout to let SeaBIOS detect the sticks.

Signed-off-by: Michał Żygowski <michal.zygowski@3mdeb.com>